### PR TITLE
Reuse CanvasElement on Flutter Web

### DIFF
--- a/flutter_gl/lib/flutter_gl.dart
+++ b/flutter_gl/lib/flutter_gl.dart
@@ -63,6 +63,7 @@ class FlutterGlPlugin extends FlutterGlPlatform {
   }
 
   dispose() {
+    openGL.disposeCanvas();
     return FlutterGlPlatform.instance.dispose_interface(this.textureId!);
   }
 }

--- a/flutter_gl/lib/openGL/OpenGL-ES.dart
+++ b/flutter_gl/lib/openGL/OpenGL-ES.dart
@@ -103,4 +103,8 @@ class OpenGLES extends OpenGLBase {
   dispose() {
     print(" OpenGLES dispose .... TODO ");
   }
+
+  void disposeCanvas() {
+    // No-op. Needed for web
+  }
 }


### PR DESCRIPTION
On Flutter Web CanvasElements are not disposed correctly if WebGL context was obtained. Apps stops rendering or get stuck when the number of used platform views gets close to 15. 
The problem is solved by reusing CanvasElements. Proper fix cannot be done because there is no API available to correctly dispose stuff in this case. 
Limitation: the fix will work with less than ~15 views are active at the same time.